### PR TITLE
Remove leftover from cosmosdb action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Allowed regions config clone directory
-.ci-config
-
 # Logs
 logs
 *.log


### PR DESCRIPTION
This must have been copied over from the Cosmos DB action. In a time before [GitHub Actions had variables](https://docs.github.com/en/actions/learn-github-actions/variables) I created this [alternate branch](https://github.com/Particular/setup-cosmosdb-action/tree/config) to hold config data, which the [action would then clone](https://github.com/Particular/setup-cosmosdb-action/blob/main/setup.ps1#L18) into a `.ci-config` directory.

The Cosmos DB action should be updated to use variables instead of that hack, now that they exist, but at least we can keep the concept from littering another repo.