### PR TITLE
Masking "postgres" just leads to problems

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -12,7 +12,6 @@ $dockerImage = "postgres:15"
 $password = [guid]::NewGuid().ToString("n")
 Write-Output "::add-mask::$password"
 $userName = "postgres"
-Write-Output "::add-mask::$userName"
 $databaseName = "postgres"
 Write-Output "::add-mask::$databaseName"
 $ipAddress = "127.0.0.1"

--- a/setup.ps1
+++ b/setup.ps1
@@ -13,7 +13,6 @@ $password = [guid]::NewGuid().ToString("n")
 Write-Output "::add-mask::$password"
 $userName = "postgres"
 $databaseName = "postgres"
-Write-Output "::add-mask::$databaseName"
 $ipAddress = "127.0.0.1"
 $port = 5432
 $runnerOs = $Env:RUNNER_OS ?? "Linux"


### PR DESCRIPTION
There is no point in masking constants from the script. Meanwhile, I'm getting this error sometimes:

```
Invoke-Expression: D:\a\_actions\Particular\setup-***-action\v1.0.0\setup.ps1:57
Line |
  57 |      $containerJson = Invoke-Expression $azureContainerCreate
     |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Unexpected token '***' in expression or statement.
Failed to create container psw-***2027516522 in WestUS3
```