### PR TITLE
Explicit value for `--os-type` parameter in container creation command

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -43,7 +43,7 @@ elseif ($runnerOs -eq "Windows") {
     # psql not in PATH on Windows
     $Env:PATH = $Env:PATH + ';' + $Env:PGBIN
        
-    $azureContainerCreate = "az container create --image $dockerImage --name $ContainerName --location $region --resource-group $resourceGroup --cpu 2 --memory 8 --ports $port --ip-address public --environment-variables POSTGRES_PASSWORD=$password POSTGRES_USER=$userName POSTGRES_DB=$databaseName --command-line 'docker-entrypoint.sh postgres --max-prepared-transactions=10'"
+    $azureContainerCreate = "az container create --image $dockerImage --name $ContainerName --location $region --resource-group $resourceGroup --cpu 2 --memory 8 --ports $port --ip-address public --os-type Linux --environment-variables POSTGRES_PASSWORD=$password POSTGRES_USER=$userName POSTGRES_DB=$databaseName --command-line 'docker-entrypoint.sh postgres --max-prepared-transactions=10'"
     if ($registryUser -and $registryPass) {
         Write-Output "Creating container with login to $RegistryLoginServer"
         $azureContainerCreate =  "$azureContainerCreate --registry-login-server $RegistryLoginServer --registry-username $RegistryUser --registry-password $RegistryPass"


### PR DESCRIPTION
Same reason as:
- https://github.com/Particular/setup-rabbitmq-action/pull/43