### PR TITLE
Switch Windows to containers running in WSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7.0.1
-      - name: Azure login
-        if: matrix.name == 'Windows'
-        uses: azure/login@v3.0.0
-        with:
-          creds: ${{ secrets.AZURE_ACI_CREDENTIALS }}
       - name: Run
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         uses: ./
         with:
           connection-string-name: PostgresConnectionString
-          tag: setup-postgres-action
           init-script: ${{ matrix.init-script.path }}
           registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
           registry-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,14 +12,13 @@ steps:
   uses: Particular/setup-postgres-action@v1.0.0
   with:
     connection-string-name: <my connection string name>
-    tag: <my tag>
     init-script: /path/to/init-posgres.sql
     registry-login-server: index.docker.io
     registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
     registry-password: ${{ secrets.DOCKERHUB_TOKEN }}}}    
 ```
 
-`connection-string-name` and `tag` are required. `init-script` is optional.
+`connection-string-name` is required. `init-script` is optional.
 
 For logging into a container registry when running on Windows:
 
@@ -84,7 +83,7 @@ To test the setup action set the required environment variables and execute `set
 
 ```bash
 $Env:RUNNER_OS=Windows
-.\setup.ps1 -ContainerName psw-postgres-1 -ConnectionStringName PostgresConnectionString -Tag setup-postgres-action
+.\setup.ps1 -ContainerName psw-postgres-1 -ConnectionStringName PostgresConnectionString
 ```
 
 To test the cleanup action set the required environment variables and execute `cleanup.ps1` with the desired parameters.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For logging into a container registry when running on Windows:
 * `registry-login-server` defaults to `index.docker.io` and is not required if logging into Docker Hub.
 * `registry-username` and `registry-password` are optional and will result in pulling the container anonymously if omitted.
 
+On Linux runners the PostgreSQL container runs directly through Docker. On Windows runners the Linux PostgreSQL container runs inside WSL2 (the action installs and starts Docker inside the WSL distribution), so no Azure Container Instances are required.
+
 ## License
 
 The scripts and documentation in this project are released under the [MIT License](LICENSE).
@@ -33,13 +35,6 @@ The scripts and documentation in this project are released under the [MIT Licens
 ## Development
 
 Open the folder in Visual Studio Code. If you don't already have them, you will be prompted to install remote development extensions. After installing them, and re-opening the folder in a container, do the following:
-
-Log into Azure
-
-```bash
-az login
-az account set --subscription SUBSCRIPTION_ID
-```
 
 Run the npm installation
 
@@ -61,10 +56,8 @@ INPUT_CONNECTION-STRING-NAME=PostgresConnectionString
 INPUT_TAG=setup-postgres-action
 
 # Runner overrides
-# Use LINUX to run on Linux
+# Use LINUX to run on Linux, WINDOWS to run on Windows via WSL2
 RUNNER_OS=WINDOWS
-RESOURCE_GROUP_OVERRIDE=yourResourceGroup
-REGION_OVERRIDE=West Europe
 ```
 
 then execute the script 
@@ -91,8 +84,6 @@ To test the setup action set the required environment variables and execute `set
 
 ```bash
 $Env:RUNNER_OS=Windows
-$Env:RESOURCE_GROUP_OVERRIDE=yourResourceGroup
-$Env:REGION_OVERRIDE=yourRegion
 .\setup.ps1 -ContainerName psw-postgres-1 -ConnectionStringName PostgresConnectionString -Tag setup-postgres-action
 ```
 
@@ -100,6 +91,5 @@ To test the cleanup action set the required environment variables and execute `c
 
 ```bash
 $Env:RUNNER_OS=Windows
-$Env:RESOURCE_GROUP_OVERRIDE=yourResourceGroup
-.\cleanup.ps1 -ContainerName psw-postgres-1 -StorageName psworacle1 -ConnectionStringName PostgresConnectionString -Tag setup-postgres-action
+.\cleanup.ps1 -ContainerName psw-postgres-1
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,6 @@ inputs:
     description: The password to log in to the container registry. Will not attempt login if not provided.
     required: false    
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
   post: dist/index.js

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ inputs:
   connection-string-name:
     description: The name of the environment variable to fill with the PostgreSQL connection string.
     required: true    
-  tag:
-    description: When the action runs on a Windows agent, this tag is applied to the Azure container which is created by the action.
-    required: true
   init-script:
     description: The path to a script to execute in PSQL when the database is available.
     required: false    

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -12,8 +12,10 @@ if ($runnerOs -eq "Linux") {
     docker rm $ContainerName
 }
 elseif ($runnerOs -eq "Windows") {
-    Write-Output "Deleting Azure container $ContainerName"
-    az container delete --resource-group $resourceGroup --name $ContainerName --yes | Out-Null
+    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Ubuntu-24.04"
+
+    Write-Output "Removing WSL Docker container $ContainerName"
+    wsl.exe --distribution $wslDistribution --user root -- bash -c "docker rm --force ${ContainerName} 2>/dev/null || true"
 }
 else {
     Write-Output "$runnerOs not supported"

--- a/cleanup.ps1
+++ b/cleanup.ps1
@@ -1,7 +1,6 @@
 param (
     [string]$ContainerName
 )
-$resourceGroup = $Env:RESOURCE_GROUP_OVERRIDE ?? "GitHubActions-RG"
 $runnerOs = $Env:RUNNER_OS ?? "Linux"
 
 if ($runnerOs -eq "Linux") {
@@ -12,7 +11,7 @@ if ($runnerOs -eq "Linux") {
     docker rm $ContainerName
 }
 elseif ($runnerOs -eq "Windows") {
-    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Ubuntu-24.04"
+    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Debian"
 
     Write-Output "Removing WSL Docker container $ContainerName"
     wsl.exe --distribution $wslDistribution --user root -- bash -c "docker rm --force ${ContainerName} 2>/dev/null || true"

--- a/dist/index.js
+++ b/dist/index.js
@@ -28069,7 +28069,6 @@ let isPost = core.getState('IsPost');
 core.saveState('IsPost', true);
 
 let connectionStringName = core.getInput('connection-string-name');
-let tag = core.getInput('tag');
 let initScript = core.getInput('init-script');
 let registryLoginServer = core.getInput('registry-login-server');
 let registryUser = core.getInput('registry-username');
@@ -28097,7 +28096,6 @@ async function run() {
                     '-ContainerName', containerName,
                     '-ConnectionStringName', connectionStringName,
                     '-InitScript', initScript,
-                    '-Tag', tag,
                     '-RegistryLoginServer', registryLoginServer,
                     '-RegistryUser', registryUser,
                     '-RegistryPass', registryPass                    

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ let isPost = core.getState('IsPost');
 core.saveState('IsPost', true);
 
 let connectionStringName = core.getInput('connection-string-name');
-let tag = core.getInput('tag');
 let initScript = core.getInput('init-script');
 let registryLoginServer = core.getInput('registry-login-server');
 let registryUser = core.getInput('registry-username');
@@ -42,7 +41,6 @@ async function run() {
                     '-ContainerName', containerName,
                     '-ConnectionStringName', connectionStringName,
                     '-InitScript', initScript,
-                    '-Tag', tag,
                     '-RegistryLoginServer', registryLoginServer,
                     '-RegistryUser', registryUser,
                     '-RegistryPass', registryPass                    

--- a/modules/WslTools/WslTools.psd1
+++ b/modules/WslTools/WslTools.psd1
@@ -1,0 +1,14 @@
+@{
+    RootModule        = 'WslTools.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    Author            = 'setup-postgres-action'
+    CompanyName       = 'Unknown'
+    Copyright         = '(c) setup-postgres-action. All rights reserved.'
+    Description       = 'Functions for interacting with WSL from GitHub Actions runners.'
+    PowerShellVersion = '7.0'
+    FunctionsToExport = @('Invoke-Wsl')
+    CmdletsToExport   = @()
+    VariablesToExport = @()
+    AliasesToExport   = @()
+}

--- a/modules/WslTools/WslTools.psd1
+++ b/modules/WslTools/WslTools.psd1
@@ -3,7 +3,7 @@
     ModuleVersion     = '1.0.0'
     GUID              = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
     Author            = 'setup-postgres-action'
-    CompanyName       = 'Unknown'
+    CompanyName       = 'Particular Software'
     Copyright         = '(c) setup-postgres-action. All rights reserved.'
     Description       = 'Functions for interacting with WSL from GitHub Actions runners.'
     PowerShellVersion = '7.0'

--- a/modules/WslTools/WslTools.psd1
+++ b/modules/WslTools/WslTools.psd1
@@ -2,9 +2,9 @@
     RootModule        = 'WslTools.psm1'
     ModuleVersion     = '1.0.0'
     GUID              = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
-    Author            = 'setup-postgres-action'
+    Author            = 'Particular Software'
     CompanyName       = 'Particular Software'
-    Copyright         = '(c) setup-postgres-action. All rights reserved.'
+    Copyright         = '© Particular Software. All rights reserved'
     Description       = 'Functions for interacting with WSL from GitHub Actions runners.'
     PowerShellVersion = '7.0'
     FunctionsToExport = @('Invoke-Wsl')

--- a/modules/WslTools/WslTools.psm1
+++ b/modules/WslTools/WslTools.psm1
@@ -1,0 +1,17 @@
+function Invoke-Wsl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Distribution,
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [switch]$CheckExitCode
+    )
+
+    wsl.exe --distribution $Distribution --user root -- bash -c $Command
+
+    if ($CheckExitCode -and $LASTEXITCODE -ne 0) {
+        throw "WSL command failed with exit code $LASTEXITCODE`: $Command"
+    }
+}
+
+Export-ModuleMember -Function Invoke-Wsl

--- a/setup.ps1
+++ b/setup.ps1
@@ -106,10 +106,12 @@ elseif ($runnerOs -eq "Windows") {
     # See https://github.com/microsoft/WSL/issues/10138 and
     # https://blog.lecoteauverdoyant.co.uk/articles/wsl-keep-alive.html
     Write-Output "Starting a D-Bus session to keep the WSL instance alive for the job"
-    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "command -v dbus-launch >/dev/null 2>&1 || { apt-get update && apt-get install -y dbus; }"
+    # dbus-launch ships in the dbus-x11 package (not dbus). Verify it is present afterwards so a
+    # packaging change can never silently leave the instance unguarded again.
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "command -v dbus-launch >/dev/null 2>&1 || { apt-get update && apt-get install -y dbus-x11; }; command -v dbus-launch >/dev/null 2>&1 || { echo 'dbus-launch is unavailable after installing dbus-x11' >&2; exit 1; }"
     wsl.exe --distribution $wslDistribution --user root --exec /usr/bin/dbus-launch true
     if ($LASTEXITCODE -ne 0) {
-        Write-Output "::warning::dbus-launch keep-alive returned exit code $LASTEXITCODE"
+        throw "dbus-launch keep-alive failed with exit code $LASTEXITCODE"
     }
 
     Write-Output "::endgroup::"

--- a/setup.ps1
+++ b/setup.ps1
@@ -18,21 +18,9 @@ $runnerOs = $Env:RUNNER_OS ?? "Linux"
 
 $env:PGPASSWORD = $password
 
-function Invoke-Wsl {
-    param(
-        [Parameter(Mandatory = $true)]
-        [string]$Distribution,
-        [Parameter(Mandatory = $true)]
-        [string]$Command,
-        [switch]$CheckExitCode
-    )
-
-    wsl.exe --distribution $Distribution --user root -- bash -c $Command
-
-    if ($CheckExitCode -and $LASTEXITCODE -ne 0) {
-        throw "WSL command failed with exit code $LASTEXITCODE`: $Command"
-    }
-}
+# Import local module containing Invoke-Wsl
+$modulePath = Join-Path $PSScriptRoot 'modules' 'WslTools'
+Import-Module $modulePath -Force
 
 if ($runnerOs -eq "Linux") {
     Write-Output "Running Postgres in container $($ContainerName) using Docker"

--- a/setup.ps1
+++ b/setup.ps1
@@ -143,7 +143,10 @@ Write-Output "::group::Testing connection"
 
 for ($i = 0; $i -lt 24; $i++) { ## 2 minute timeout
     Write-Output "Checking for PostgreSQL connectivity $($i+1)/30..."
-    psql --host $ipAddress --username=$userName --list > $null
+    # SELECT 1 is version-agnostic. `--list` runs a catalog query whose column names change
+    # across major versions (e.g. daticulocale -> datlocale), which breaks when the runner's
+    # older psql client probes a newer server (psql 15/16 vs postgres:18).
+    psql --host $ipAddress --username=$userName --command "SELECT 1" > $null
     if ($?) {
         Write-Output "Connection successful"
       break;

--- a/setup.ps1
+++ b/setup.ps1
@@ -20,59 +20,95 @@ $resourceGroup = $Env:RESOURCE_GROUP_OVERRIDE ?? "GitHubActions-RG"
 
 $env:PGPASSWORD = $password
 
+function Invoke-Wsl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Distribution,
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [switch]$CheckExitCode
+    )
+
+    wsl.exe --distribution $Distribution --user root -- bash -c $Command
+
+    if ($CheckExitCode -and $LASTEXITCODE -ne 0) {
+        throw "WSL command failed with exit code $LASTEXITCODE`: $Command"
+    }
+}
+
 if ($runnerOs -eq "Linux") {
     Write-Output "Running Postgres in container $($ContainerName) using Docker"
 
     docker run --name "$($ContainerName)" -d -p "$($port):$($port)" -e POSTGRES_PASSWORD=$password -e POSTGRES_USER=$userName -e POSTGRES_DB=$databaseName $dockerImage -c max_prepared_transactions=10
 }
 elseif ($runnerOs -eq "Windows") {
-    Write-Output "Running Postgres in container $($ContainerName) using Azure"
+    Write-Output "Running Postgres in container $($ContainerName) using WSL"
 
-    if ($Env:REGION_OVERRIDE) {
-        $region = $Env:REGION_OVERRIDE
-    }
-    else {
-        $hostInfo = curl -H Metadata:true "169.254.169.254/metadata/instance?api-version=2017-08-01" | ConvertFrom-Json
-        $region = $hostInfo.compute.location
-    }
-
-    $runnerOsTag = "RunnerOS=$($runnerOs)"
-    $packageTag = "Package=$Tag"
-    $dateTag = "Created=$(Get-Date -Format "yyyy-MM-dd")"
-
-    # psql not in PATH on Windows
+    # psql is not in PATH on Windows
     $Env:PATH = $Env:PATH + ';' + $Env:PGBIN
 
-    $azureContainerCreate = "az container create --image $dockerImage --name $ContainerName --location $region --resource-group $resourceGroup --cpu 2 --memory 8 --ports $port --ip-address public --os-type Linux --environment-variables POSTGRES_PASSWORD=$password POSTGRES_USER=$userName POSTGRES_DB=$databaseName --command-line 'docker-entrypoint.sh postgres --max-prepared-transactions=10'"
+    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Ubuntu-24.04"
+
+    Write-Output "::group::Preparing WSL ($wslDistribution)"
+
+    wsl.exe --set-default-version 2 | Out-Null
+
+    # Install the distribution if it is not already registered.
+    $installedDistributions = ((wsl.exe --list --quiet) -replace "`0", "") |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne "" }
+
+    if ($installedDistributions -notcontains $wslDistribution) {
+        Write-Output "Installing $wslDistribution in WSL"
+        wsl.exe --install $wslDistribution --web-download --no-launch
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to install $wslDistribution in WSL"
+        }
+    }
+    else {
+        Write-Output "$wslDistribution is already installed"
+    }
+
+    # Ensure Docker is installed inside the WSL distribution.
+    Write-Output "Ensuring Docker is installed inside $wslDistribution"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "command -v docker >/dev/null 2>&1 || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --yes docker.io; }"
+
+    # Start the Docker daemon. Systemd is enabled by default on Ubuntu-24.04.
+    Write-Output "Starting Docker daemon inside $wslDistribution"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker info >/dev/null 2>&1 || systemctl start docker || service docker start"
+
+    # Optionally log in to the container registry to avoid rate limits when pulling.
     if ($registryUser -and $registryPass) {
-        Write-Output "Creating container with login to $RegistryLoginServer"
-        $azureContainerCreate =  "$azureContainerCreate --registry-login-server $RegistryLoginServer --registry-username $RegistryUser --registry-password $RegistryPass"
-    } else {
-        Write-Output "Creating container with anonymous credentials"
+        Write-Output "::add-mask::$registryPass"
+        Write-Output "Logging in to $RegistryLoginServer inside WSL"
+        $loginCommand = "docker login --username '$RegistryUser' --password-stdin '$RegistryLoginServer'"
+        $registryPass | wsl.exe --distribution $wslDistribution --user root -- bash -c $loginCommand
+        if ($LASTEXITCODE -ne 0) {
+            throw "Docker registry login inside WSL failed with exit code $LASTEXITCODE"
+        }
+    }
+    else {
+        Write-Output "Using anonymous credentials"
     }
 
-    Write-Output "Creating container $ContainerName in $region (this can take a while)"
-    $containerJson = Invoke-Expression $azureContainerCreate
+    Write-Output "::endgroup::"
 
-    if (!$containerJson) {
-        Write-Output "Failed to create container $ContainerName in $region"
-        exit 1;
+    Write-Output "::group::Starting PostgreSQL container"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker run --name $ContainerName --detach --publish ${port}:${port} -e POSTGRES_PASSWORD='$password' -e POSTGRES_USER='$userName' -e POSTGRES_DB='$databaseName' $dockerImage -c max_prepared_transactions=10"
+
+    # Determine the WSL VM IPv4 address so that Windows can reach the published port.
+    $wslIp = ((wsl.exe --distribution $wslDistribution --user root -- hostname -I) -replace "`0", "").Trim().Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries) |
+        Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } |
+        Select-Object -First 1
+
+    if (-not $wslIp) {
+        throw "Could not determine the WSL IPv4 address"
     }
 
-    $containerDetails = $containerJson | ConvertFrom-Json
+    $ipAddress = $wslIp
+    Write-Output "WSL address: $ipAddress"
 
-    if (!$containerDetails.ipAddress) {
-        Write-Output "Failed to create container $ContainerName in $region"
-        Write-Output $containerJson
-        exit 1;
-    }
-
-    $ipAddress = $containerDetails.ipAddress.ip
-    Write-Output "::add-mask::$ipAddress"
-
-    Write-Output "Tagging the container"
-    az tag create --resource-id $containerDetails.id --tags $packageTag $runnerOsTag $dateTag | Out-Null
-
+    Write-Output "::endgroup::"
 }
 else {
     Write-Output "$runnerOs not supported"

--- a/setup.ps1
+++ b/setup.ps1
@@ -2,7 +2,6 @@ param (
     [string]$ContainerName,
     [string]$ConnectionStringName,
     [string]$InitScript = "",
-    [string]$Tag,
     [string]$RegistryLoginServer = "index.docker.io",
     [string]$RegistryUser,
     [string]$RegistryPass
@@ -16,7 +15,6 @@ $databaseName = "postgres"
 $ipAddress = "127.0.0.1"
 $port = 5432
 $runnerOs = $Env:RUNNER_OS ?? "Linux"
-$resourceGroup = $Env:RESOURCE_GROUP_OVERRIDE ?? "GitHubActions-RG"
 
 $env:PGPASSWORD = $password
 
@@ -47,7 +45,7 @@ elseif ($runnerOs -eq "Windows") {
     # psql is not in PATH on Windows
     $Env:PATH = $Env:PATH + ';' + $Env:PGBIN
 
-    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Ubuntu-24.04"
+    $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Debian"
 
     Write-Output "::group::Preparing WSL ($wslDistribution)"
 
@@ -73,9 +71,9 @@ elseif ($runnerOs -eq "Windows") {
     Write-Output "Ensuring Docker is installed inside $wslDistribution"
     Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "command -v docker >/dev/null 2>&1 || { apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --yes docker.io; }"
 
-    # Start the Docker daemon. Systemd is enabled by default on Ubuntu-24.04.
+    # Start the Docker daemon via systemd when available, otherwise via the SysV service.
     Write-Output "Starting Docker daemon inside $wslDistribution"
-    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker info >/dev/null 2>&1 || systemctl start docker || service docker start"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker info >/dev/null 2>&1 || { if [ -d /run/systemd/system ]; then systemctl start docker; else service docker start; fi; }"
 
     # Optionally log in to the container registry to avoid rate limits when pulling.
     if ($registryUser -and $registryPass) {

--- a/setup.ps1
+++ b/setup.ps1
@@ -47,6 +47,16 @@ elseif ($runnerOs -eq "Windows") {
 
     $wslDistribution = $Env:WSL_DISTRIBUTION_OVERRIDE ?? "Debian"
 
+    # Constrain the WSL2 VM (memory) and keep it from being shut down when idle, so that Docker
+    # and the container are not torn down between this setup step and the test step. Only write
+    # when the file is absent so local development configurations are left untouched.
+    $wslConfigPath = Join-Path $Env:USERPROFILE ".wslconfig"
+    if (-not (Test-Path $wslConfigPath)) {
+        $wslMemory = $Env:WSL_MEMORY_OVERRIDE ?? "3GB"
+        Write-Output "Writing $wslConfigPath (memory=$wslMemory) to constrain the WSL2 VM"
+        Set-Content -Path $wslConfigPath -Value "[wsl2]`nmemory=$wslMemory`nvmIdleTimeout=-1" -Encoding ASCII
+    }
+
     Write-Output "::group::Preparing WSL ($wslDistribution)"
 
     wsl.exe --set-default-version 2 | Out-Null
@@ -89,10 +99,24 @@ elseif ($runnerOs -eq "Windows") {
         Write-Output "Using anonymous credentials"
     }
 
+    # Keep the WSL instance alive for the rest of the job. WSL terminates an instance when no
+    # processes remain under its init (PID 2); a plain background process (e.g. sleep) does not
+    # prevent this, but a D-Bus session bus launched through `wsl --exec` does. vmIdleTimeout
+    # above covers the VM-level idle timeout; this covers the separate instance-level shutdown.
+    # See https://github.com/microsoft/WSL/issues/10138 and
+    # https://blog.lecoteauverdoyant.co.uk/articles/wsl-keep-alive.html
+    Write-Output "Starting a D-Bus session to keep the WSL instance alive for the job"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "command -v dbus-launch >/dev/null 2>&1 || { apt-get update && apt-get install -y dbus; }"
+    wsl.exe --distribution $wslDistribution --user root --exec /usr/bin/dbus-launch true
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "::warning::dbus-launch keep-alive returned exit code $LASTEXITCODE"
+    }
+
     Write-Output "::endgroup::"
 
     Write-Output "::group::Starting PostgreSQL container"
-    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker run --name $ContainerName --detach --publish ${port}:${port} -e POSTGRES_PASSWORD='$password' -e POSTGRES_USER='$userName' -e POSTGRES_DB='$databaseName' $dockerImage -c max_prepared_transactions=10"
+    Invoke-Wsl -Distribution $wslDistribution -CheckExitCode -Command "docker run --name $ContainerName --detach --restart unless-stopped --publish ${port}:${port} -e POSTGRES_PASSWORD='$password' -e POSTGRES_USER='$userName' -e POSTGRES_DB='$databaseName' $dockerImage -c max_prepared_transactions=10"
+    Invoke-Wsl -Distribution $wslDistribution -Command "docker ps --filter name=$ContainerName"
 
     # Determine the WSL VM IPv4 address so that Windows can reach the published port.
     $wslIp = ((wsl.exe --distribution $wslDistribution --user root -- hostname -I) -replace "`0", "").Trim().Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries) |


### PR DESCRIPTION
This pull request significantly refactors the action to remove all dependencies on Azure Container Instances for Windows runners. Instead, it now runs PostgreSQL inside a WSL2-based Docker container on Windows runners, aligning the approach with Linux runners and simplifying the setup and cleanup processes. The documentation and input parameters have been updated to reflect these architectural changes.

**Major architectural changes:**

* Replaced the use of Azure Container Instances on Windows runners with WSL2-based Docker containers. The scripts now install and manage Docker inside a WSL2 distribution, launch the PostgreSQL container there, and ensure the WSL instance remains alive for the duration of the job. (Ffa4187eL15R15, [cleanup.ps1L15-R17](diffhunk://#diff-f70bb0b0715a43a0f4a95c52a9143806a6b6feb8f8b63892db3b04d8daab8e06L15-R17))
* Removed all Azure login and resource group management steps from the workflow, scripts, and documentation. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL33-L42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-L43) [[3]](diffhunk://#diff-f70bb0b0715a43a0f4a95c52a9143806a6b6feb8f8b63892db3b04d8daab8e06L4) [[4]](diffhunk://#diff-07cad9ba475de213740a6ebb3f2e6729d3071f16d479a193e34d36c601932612L19-R135)

**Input and interface changes:**

* Removed the `tag` input parameter from the action (`action.yml`, `index.js`, `setup.ps1`, and related workflow/example usages). The action interface is now simpler, and the documentation has been updated to indicate that only the connection string name is required. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L7-L9) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L17) [[3]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L45) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R29) [[5]](diffhunk://#diff-07cad9ba475de213740a6ebb3f2e6729d3071f16d479a193e34d36c601932612L5) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-L67) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R93)

**Documentation and usage updates:**

* Updated the `README.md` to clarify that on Windows runners, PostgreSQL runs inside WSL2 and no Azure resources are needed. Simplified setup and cleanup instructions, and removed references to Azure-specific environment variables and steps. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-L43) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-L67) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R93)

**Script and reliability improvements:**

* Added logic to automatically install and configure WSL2 distributions, constrain VM resources, and keep the WSL instance alive using a D-Bus session. Improved error handling and output for these steps. (Ffa4187eL15R15)
* Changed the PostgreSQL connectivity check to use a version-agnostic `SELECT 1` query instead of `--list`, improving compatibility with different server/client versions.

These changes make the action easier to use, more consistent across operating systems, and remove the requirement for Azure access on Windows runners.